### PR TITLE
fixed looping error to game search

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -151,6 +151,7 @@ $(document).ready(() => {
           </div>
           `;
           //console.log(html);
+          $("#output").empty();
           $("#output").append(html);
         }
       })


### PR DESCRIPTION
After searching for a game, the script would return a user list of whoever had that game and re-append every time the Search button was clicked. This error was fixed so that only one set of users will return.